### PR TITLE
Fixed json parsing

### DIFF
--- a/mysql_ch_replicator/pymysqlreplication/packet.py
+++ b/mysql_ch_replicator/pymysqlreplication/packet.py
@@ -347,7 +347,7 @@ class BinLogPacketWrapper(object):
             # handle NULL value
             return None
         data = self.read(length)
-        return cpp_mysql_to_json(data)
+        return cpp_mysql_to_json(data).decode('utf-8')
 
         #
         # if is_partial:


### PR DESCRIPTION
Json was wrongly parsed as `"{\"b\": \"b\", \"c\": [3, 2, 1]}"`. Now it's parsed correctly as `{"b": "b", "c": [3, 2, 1]}` (before there were additional quotes).