### PR TITLE
Support for indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,20 @@ binlog_replicator:
 databases: 'database_name_pattern_*'
 tables: '*'
 
+
+# OPTIONAL SETTINGS
+
 exclude_databases: ['database_10', 'database_*_42']   # optional
 exclude_tables: ['meta_table_*']                      # optional
 
 log_level: 'info'         # optional       
 optimize_interval: 86400  # optional
+
+indexes:                  # optional
+  - databases: '*'
+    tables: ['test_table']
+    index: 'INDEX name_idx name TYPE ngrambf_v1(5, 65536, 4, 0) GRANULARITY 1'
+
 ```
 
 #### Required settings
@@ -154,6 +163,7 @@ optimize_interval: 86400  # optional
 - `exclude_tables` - databases to __exclude__, string or list. If same table matches `tables` and `exclude_tables`, exclude has higher priority.
 - `log_level` - log level, default is `info`, you can set to `debug` to get maximum information (allowed values are `debug`, `info`, `warning`, `error`, `critical`)
 - `optimize_interval` - interval (seconds) between automatic `OPTIMIZE table FINAL` calls. Default 86400 (1 day). This is required to perform all merges guaranteed and avoid increasing of used storage and decreasing performance.
+- `indexes` - you may want to add some indexes to accelerate performance, eg. ngram index for full-test search, etc. To apply indexes you need to start replication from scratch.
 
 Few more tables / dbs examples:
 

--- a/mysql_ch_replicator/converter.py
+++ b/mysql_ch_replicator/converter.py
@@ -472,7 +472,7 @@ class MysqlToClickhouseConverter:
                 query = f'ALTER TABLE {db_name}.{table_name} RENAME COLUMN {column_name} TO {new_column_name}'
                 self.db_replicator.clickhouse_api.execute_command(query)
 
-    def parse_create_table_query(self, mysql_query) -> tuple:
+    def parse_create_table_query(self, mysql_query) -> tuple[TableStructure, TableStructure]:
         mysql_table_structure = self.parse_mysql_table_structure(mysql_query)
         ch_table_structure = self.convert_table_structure(mysql_table_structure)
         return mysql_table_structure, ch_table_structure

--- a/mysql_ch_replicator/db_replicator.py
+++ b/mysql_ch_replicator/db_replicator.py
@@ -214,7 +214,8 @@ class DbReplicator:
         self.validate_mysql_structure(mysql_structure)
         clickhouse_structure = self.converter.convert_table_structure(mysql_structure)
         self.state.tables_structure[table_name] = (mysql_structure, clickhouse_structure)
-        self.clickhouse_api.create_table(clickhouse_structure)
+        indexes = self.config.get_indexes(self.database, table_name)
+        self.clickhouse_api.create_table(clickhouse_structure, additional_indexes=indexes)
 
     def prevent_binlog_removal(self):
         if time.time() - self.last_touch_time < self.BINLOG_TOUCH_INTERVAL:
@@ -480,7 +481,8 @@ class DbReplicator:
         if not self.config.is_table_matches(mysql_structure.table_name):
             return
         self.state.tables_structure[mysql_structure.table_name] = (mysql_structure, ch_structure)
-        self.clickhouse_api.create_table(ch_structure)
+        indexes = self.config.get_indexes(self.database, ch_structure.table_name)
+        self.clickhouse_api.create_table(ch_structure, additional_indexes=indexes)
 
     def handle_drop_table_query(self, query, db_name):
         tokens = query.split()

--- a/test_mysql_ch_replicator.py
+++ b/test_mysql_ch_replicator.py
@@ -366,7 +366,22 @@ CREATE TABLE {TEST_TABLE_NAME} (
     assert_wait(lambda: len(ch.select(TEST_TABLE_NAME, final=False)) == 4)
 
     mysql.create_database(TEST_DB_NAME_2)
-    assert_wait(lambda: TEST_DB_NAME_2 in ch.get_databases(), max_wait_time=5)
+    assert_wait(lambda: TEST_DB_NAME_2 in ch.get_databases())
+
+    mysql.execute(f'''
+    CREATE TABLE test_table_with_index (
+        id int NOT NULL AUTO_INCREMENT,
+        name varchar(255) NOT NULL,
+        age int,
+        rate decimal(10,4),
+        PRIMARY KEY (id)
+    ); 
+        ''')
+
+    assert_wait(lambda: 'test_table_with_index' in ch.get_tables())
+
+    create_query = ch.show_create_table('test_table_with_index')
+    assert 'INDEX name_idx name TYPE ngrambf_v1' in create_query
 
     run_all_runner.stop()
 

--- a/tests_config.yaml
+++ b/tests_config.yaml
@@ -19,3 +19,8 @@ databases: '*test*'
 log_level: 'debug'
 optimize_interval: 3
 check_db_updated_interval: 3
+
+indexes:
+  - databases: '*'
+    tables: ['test_table_with_index']
+    index: 'INDEX name_idx name TYPE ngrambf_v1(5, 65536, 4, 0) GRANULARITY 1'


### PR DESCRIPTION
Now you could add indexes to config:

```
indexes:
  - databases: '*'
    tables: ['test_table']
    index: 'INDEX name_idx name TYPE ngrambf_v1(5, 65536, 4, 0) GRANULARITY 1'
```