### PR TITLE
Strip db name from token in create table queries (#70)

### DIFF
--- a/mysql_ch_replicator/converter.py
+++ b/mysql_ch_replicator/converter.py
@@ -585,7 +585,9 @@ class MysqlToClickhouseConverter:
         if not isinstance(tokens[2], sqlparse.sql.Identifier):
             raise Exception('wrong create statement', create_statement)
 
-        structure.table_name = strip_sql_name(tokens[2].normalized)
+        # get_real_name() returns the table name if the token is in the
+        # style `<dbname>.<tablename>`
+        structure.table_name = strip_sql_name(tokens[2].get_real_name())
 
         if not isinstance(tokens[3], sqlparse.sql.Parenthesis):
             raise Exception('wrong create statement', create_statement)


### PR DESCRIPTION
When creating a table and specifying the dbname in mysql (`create table testdb.foo (bar int not null)`), the table name became `testdb.foo`, and in the statement to create the table in ClickHouse the database name was prepended again to get `testdb.testdb.foo`.

This change uses `get_real_name()` in `sqlparse` to get just the table name with the parent (in this case db) name stripped off.