### PR TITLE
Fix create drop table if exists

### DIFF
--- a/mysql_ch_replicator/clickhouse_api.py
+++ b/mysql_ch_replicator/clickhouse_api.py
@@ -14,7 +14,7 @@ logger = getLogger(__name__)
 
 
 CREATE_TABLE_QUERY = '''
-CREATE TABLE {db_name}.{table_name}
+CREATE TABLE {if_not_exists} {db_name}.{table_name}
 (
 {fields},
     `_version` UInt64,
@@ -165,6 +165,7 @@ class ClickhouseApi:
             primary_key = f'({primary_key})'
 
         query = CREATE_TABLE_QUERY.format(**{
+            'if_not_exists': 'IF NOT EXISTS' if structure.if_not_exists else '',
             'db_name': self.database,
             'table_name': structure.table_name,
             'fields': fields,

--- a/mysql_ch_replicator/converter.py
+++ b/mysql_ch_replicator/converter.py
@@ -262,6 +262,7 @@ class MysqlToClickhouseConverter:
     def convert_table_structure(self, mysql_structure: TableStructure) -> TableStructure:
         clickhouse_structure = TableStructure()
         clickhouse_structure.table_name = mysql_structure.table_name
+        clickhouse_structure.if_not_exists = mysql_structure.if_not_exists
         for field in mysql_structure.fields:
             clickhouse_field_type = self.convert_field_type(field.field_type, field.parameters)
             clickhouse_structure.fields.append(TableField(


### PR DESCRIPTION
Two fixes:
 - `CREATE TABLE IF NOT EXISTS` already worked if the table didn't exist, but still tried to create it a second time if it did, so I passed it on from mysql_structure to clickhouse_structure and modified the `CREATE` statement
 - `DROP TABLE IF EXISTS` didn't work for similar reasons. I tried to follow the pattern for `CREATE` to fix this.

If you prefer an issue to be opened for fixes like this, then let me know and I'll open one