### PR TITLE
Add customizable PARTITION BY support for ClickHouse tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,11 @@ indexes:                        # optional
     tables: ['test_table']
     index: 'INDEX name_idx name TYPE ngrambf_v1(5, 65536, 4, 0) GRANULARITY 1'
 
+partition_bys:                  # optional
+  - databases: '*'
+    tables: ['test_table']
+    partition_by: 'toYYYYMM(created_at)'
+
 http_host: '0.0.0.0'    # optional
 http_port: 9128         # optional
 
@@ -258,6 +263,7 @@ ignore_deletes: false    # optional, set to true to ignore DELETE operations
 - `auto_restart_interval` - interval (seconds) between automatic db_replicator restart. Default 3600 (1 hour). This is done to reduce memory usage.
 - `binlog_retention_period` - how long to keep binlog files in seconds. Default 43200 (12 hours). This setting controls how long the local binlog files are retained before being automatically cleaned up.
 - `indexes` - you may want to add some indexes to accelerate performance, eg. ngram index for full-test search, etc. To apply indexes you need to start replication from scratch.
+- `partition_bys` - custom PARTITION BY expressions for tables. By default uses `intDiv(id, 4294967)` for integer primary keys. Useful for time-based partitioning like `toYYYYMM(created_at)`.
 - `http_host`, `http_port` - http endpoint to control replication, use `/docs` for abailable commands
 - `types_mappings` - custom types mapping, eg. you can map char(36) to UUID instead of String, etc.
 - `ignore_deletes` - when set to `true`, DELETE operations in MySQL will be ignored during replication. This creates an append-only model where data is only added, never removed. In this mode, the replicator doesn't create a temporary database and instead replicates directly to the target database.

--- a/mysql_ch_replicator/db_replicator_initial.py
+++ b/mysql_ch_replicator/db_replicator_initial.py
@@ -54,9 +54,10 @@ class DbReplicatorInitial:
         
         self.replicator.state.tables_structure[table_name] = (mysql_structure, clickhouse_structure)
         indexes = self.replicator.config.get_indexes(self.replicator.database, table_name)
+        partition_bys = self.replicator.config.get_partition_bys(self.replicator.database, table_name)
 
         if not self.replicator.is_parallel_worker:
-            self.replicator.clickhouse_api.create_table(clickhouse_structure, additional_indexes=indexes)
+            self.replicator.clickhouse_api.create_table(clickhouse_structure, additional_indexes=indexes, additional_partition_bys=partition_bys)
 
     def validate_mysql_structure(self, mysql_structure: TableStructure):
         for key_idx in mysql_structure.primary_key_ids:

--- a/mysql_ch_replicator/db_replicator_realtime.py
+++ b/mysql_ch_replicator/db_replicator_realtime.py
@@ -201,7 +201,8 @@ class DbReplicatorRealtime:
             return
         self.replicator.state.tables_structure[mysql_structure.table_name] = (mysql_structure, ch_structure)
         indexes = self.replicator.config.get_indexes(self.replicator.database, ch_structure.table_name)
-        self.replicator.clickhouse_api.create_table(ch_structure, additional_indexes=indexes)
+        partition_bys = self.replicator.config.get_partition_bys(self.replicator.database, ch_structure.table_name)
+        self.replicator.clickhouse_api.create_table(ch_structure, additional_indexes=indexes, additional_partition_bys=partition_bys)
 
     def handle_drop_table_query(self, query, db_name):
         tokens = query.split()

--- a/test_mysql_ch_replicator.py
+++ b/test_mysql_ch_replicator.py
@@ -134,6 +134,11 @@ CREATE TABLE `{TEST_TABLE_NAME}` (
     assert_wait(lambda: TEST_TABLE_NAME in ch.get_tables())
     assert_wait(lambda: len(ch.select(TEST_TABLE_NAME)) == 2)
 
+    # Check for custom partition_by configuration when using CONFIG_FILE (tests_config.yaml)
+    if config_file == CONFIG_FILE:
+        create_query = ch.show_create_table(TEST_TABLE_NAME)
+        assert 'PARTITION BY toYYYYMM(toDate(id))' in create_query, f"Custom partition_by not found in CREATE TABLE query: {create_query}"
+
     mysql.execute(f"INSERT INTO `{TEST_TABLE_NAME}` (name, age) VALUES ('Filipp', 50);", commit=True)
     assert_wait(lambda: len(ch.select(TEST_TABLE_NAME)) == 3)
     assert_wait(lambda: ch.select(TEST_TABLE_NAME, where="name='Filipp'")[0]['age'] == 50)

--- a/tests_config.yaml
+++ b/tests_config.yaml
@@ -28,6 +28,11 @@ indexes:
     tables: ['group']
     index: 'INDEX name_idx name TYPE ngrambf_v1(5, 65536, 4, 0) GRANULARITY 1'
 
+partition_bys:
+  - databases: '*test*'
+    tables: ['test_table']
+    partition_by: 'toYYYYMM(toDate(id))'
+
 http_host: 'localhost'
 http_port: 9128
 


### PR DESCRIPTION
## Summary

Adds support for customizable `PARTITION BY` expressions in ClickHouse table creation to address issues with Snowflake IDs creating too many partitions.

## Changes

- **New config option**: `partition_bys` with database/table filtering (similar to `indexes`)
- **Custom expressions**: Override default `intDiv(id, 4294967)` with user-defined partition logic
- **Backward compatible**: Falls back to existing behavior when not configured
- **Test coverage**: Modified existing test to verify custom partition functionality

## Configuration Example

```yaml
partition_bys:
  - databases: '*'
    tables: ['test_table']
    partition_by: 'toYYYYMM(created_at)'
```

## Problem Solved

Fixes issue where Snowflake-style IDs (e.g., `1849360358546407424`) with default partitioning create excessive partitions, triggering `max_partitions_per_insert_block` limits. Users can now specify time-based partitioning like `toYYYYMM(created_at)`.

Fixes #161