### PR TITLE
Add charset option

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ mysql:
   port: 8306
   user: 'root'
   password: 'root'
+  charset: 'utf8mb4'  # optional, default is utf8mb4 for full Unicode support
 
 clickhouse:
   host: 'localhost'

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -4,6 +4,7 @@ mysql:
   port: 8306
   user: 'root'
   password: 'root'
+  charset: 'utf8mb4'  # Optional: charset for MySQL connection (default: utf8mb4). Use utf8mb4 for full Unicode support including emoji and 4-byte characters
 
 clickhouse:
   host: 'localhost'

--- a/mysql_ch_replicator/binlog_replicator.py
+++ b/mysql_ch_replicator/binlog_replicator.py
@@ -351,6 +351,7 @@ class BinlogReplicator:
             'port': self.mysql_settings.port,
             'user': self.mysql_settings.user,
             'passwd': self.mysql_settings.password,
+            'charset': self.mysql_settings.charset,
         }
         self.data_writer = DataWriter(self.replicator_settings)
         self.state = State(os.path.join(self.replicator_settings.data_dir, 'state.json'))

--- a/mysql_ch_replicator/config.py
+++ b/mysql_ch_replicator/config.py
@@ -15,6 +15,7 @@ class MysqlSettings:
     port: int = 3306
     user: str = 'root'
     password: str = ''
+    charset: str = 'utf8mb4'  # Default to utf8mb4 for full Unicode support
 
     def validate(self):
         if not isinstance(self.host, str):
@@ -28,6 +29,9 @@ class MysqlSettings:
 
         if not isinstance(self.password, str):
             raise ValueError(f'mysql password should be string and not {stype(self.password)}')
+        
+        if not isinstance(self.charset, str):
+            raise ValueError(f'mysql charset should be string and not {stype(self.charset)}')
 
 
 @dataclass

--- a/mysql_ch_replicator/mysql_api.py
+++ b/mysql_ch_replicator/mysql_api.py
@@ -28,6 +28,12 @@ class MySQLApi:
             user=self.mysql_settings.user,
             passwd=self.mysql_settings.password,
         )
+        # Use charset from config if available
+        if hasattr(self.mysql_settings, 'charset'):
+            conn_settings['charset'] = self.mysql_settings.charset
+            # Set appropriate collation based on charset
+            if self.mysql_settings.charset == 'utf8mb4':
+                conn_settings['collation'] = 'utf8mb4_unicode_ci'
         try:
             self.db = mysql.connector.connect(**conn_settings)
         except mysql.connector.errors.DatabaseError as e:


### PR DESCRIPTION
Our team added i18n support to some fields by converting them to JSON fields and adding language key-value pairs.

Upon replicating to ClickHouse, we encountered an issue where the Arabic translations are being shown with unicode escaped format. Showing like this:

<img width="743" height="172" alt="image" src="https://github.com/user-attachments/assets/9f45f1a2-50cc-467a-b1dc-9f2ddc90be01" />


Our MySQL charset settings:
```sql
SHOW VARIABLES LIKE 'character_set%';
SHOW VARIABLES LIKE 'collation%';
SHOW SESSION VARIABLES LIKE 'character_set%';

-- Output:
character_set_client	utf8mb4
character_set_connection	utf8mb4
character_set_database	utf8mb4
character_set_filesystem	binary
character_set_results	utf8mb4
character_set_server	utf8mb4
character_set_system	utf8mb3
character_sets_dir	/usr/share/mysql/charsets/
```

So I tried changing the replicator's charset for the settings, API and binlog, and it worked.

However, I wasn't able to reproduce the issue (with the same docker containers setup). Hence, the test added in this PR isn't verified.