### PR TITLE
Fixed primary key handling logic in `db_replicator_initial.py`.

### DIFF
--- a/mysql_ch_replicator/db_replicator_initial.py
+++ b/mysql_ch_replicator/db_replicator_initial.py
@@ -170,8 +170,9 @@ class DbReplicatorInitial:
 
         while True:
 
-            query_start_values = max_primary_key
-            if query_start_values is not None:
+            query_start_values = None
+            if max_primary_key is not None:
+                query_start_values = max_primary_key.copy()
                 for i in range(len(query_start_values)):
                     key_type = primary_key_types[i]
                     value = query_start_values[i]


### PR DESCRIPTION
Fixed an issue with a datetime column used in the primary key.
The problem occurred because max_primary_key was treated as a string, which caused the comparison in the max() method to fail.