### PR TITLE
Ignore convert operation

### DIFF
--- a/mysql_ch_replicator/converter.py
+++ b/mysql_ch_replicator/converter.py
@@ -767,6 +767,9 @@ class MysqlToClickhouseConverter:
             if op_name == 'auto_increment':
                 continue
 
+            if op_name == 'convert':
+                continue
+
             if op_name == 'change':
                 self.__convert_alter_table_change_column(db_name, table_name, tokens)
                 continue

--- a/tests/test_ddl_operations.py
+++ b/tests/test_ddl_operations.py
@@ -191,6 +191,11 @@ CREATE TABLE `{TEST_TABLE_NAME}` (
     # Test add KEY
     mysql.execute(
         f"ALTER TABLE `{TEST_TABLE_NAME}` ADD KEY `idx_c1_c2` (`c1`,`c2`)")
+
+    # Test CONVERT TO CHARACTER SET (should be ignored)
+    mysql.execute(
+        f"ALTER TABLE `{TEST_TABLE_NAME}` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
+
     mysql.execute(
         f"INSERT INTO `{TEST_TABLE_NAME}` (id, c1, c2) VALUES (46, 333, 444)",
         commit=True,


### PR DESCRIPTION
Query like this was breaking replication:

```ALTER TABLE `tag` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;```

Now we will ignore convert operations.